### PR TITLE
Use the config device when specified

### DIFF
--- a/backend/fake.go
+++ b/backend/fake.go
@@ -2,6 +2,9 @@ package backend
 
 import (
 	"io"
+
+	"github.com/google/go-attestation/attest"
+	"github.com/google/go-tpm/tpm2/transport"
 )
 
 // FakeTPM is a wrapper for fake TPM devices
@@ -21,4 +24,67 @@ func (*FakeTPM) MeasurementLog() ([]byte, error) { return fixedLog, nil }
 // Fake returns a fake TPM-satisfying interface from a ReadWriteCloser
 func Fake(rw io.ReadWriteCloser) *FakeTPM {
 	return &FakeTPM{ReadWriteCloser: rw}
+}
+
+// transportCommandChannel wraps a transport.TPM to implement attest.CommandChannelTPM20
+// It adapts the transport.TPM Send interface to ReadWriteCloser
+type transportCommandChannel struct {
+	tpm transport.TPM
+	// Buffer for pending reads
+	readBuf []byte
+	readPos int
+}
+
+// Read reads data from the TPM response buffer
+func (t *transportCommandChannel) Read(p []byte) (int, error) {
+	if t.readPos >= len(t.readBuf) {
+		return 0, io.EOF
+	}
+	n := copy(p, t.readBuf[t.readPos:])
+	t.readPos += n
+	return n, nil
+}
+
+// Write sends a command to the TPM and buffers the response
+func (t *transportCommandChannel) Write(p []byte) (int, error) {
+	response, err := t.tpm.Send(p)
+	if err != nil {
+		return 0, err
+	}
+	// Buffer the response for Read
+	t.readBuf = response
+	t.readPos = 0
+	return len(p), nil
+}
+
+// Send sends a command to the TPM and returns the response
+func (t *transportCommandChannel) Send(command []byte) ([]byte, error) {
+	return t.tpm.Send(command)
+}
+
+// MeasurementLog returns empty log data (not used for real TPMs)
+func (t *transportCommandChannel) MeasurementLog() ([]byte, error) {
+	return nil, nil
+}
+
+// Close closes the underlying TPM transport if it implements io.Closer
+func (t *transportCommandChannel) Close() error {
+	if closer, ok := t.tpm.(transport.TPMCloser); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+// FromTransport creates a CommandChannelTPM20 from a transport.TPM
+// forwarding commands to the underlying transport.TPM.
+//
+// Parameters:
+//
+//	tpm - the transport.TPM to be adapted
+//
+// Returns:
+//
+//	An implementation of attest.CommandChannelTPM20 that wraps the provided transport.TPM.
+func FromTransport(tpm transport.TPM) attest.CommandChannelTPM20 {
+	return &transportCommandChannel{tpm: tpm}
 }

--- a/tpm.go
+++ b/tpm.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/go-attestation/attest"
 	"github.com/google/go-tpm-tools/simulator"
+	"github.com/google/go-tpm/tpm2/transport"
 	"github.com/kairos-io/tpm-helpers/backend"
 	"github.com/pkg/errors"
 )
@@ -47,11 +48,18 @@ func getTPM(c *config) (*attest.TPM, error) {
 	cfg := &attest.OpenConfig{
 		TPMVersion: attest.TPMVersion20,
 	}
+
+	// Priority: commandChannel > device > emulated
 	if c.commandChannel != nil {
 		cfg.CommandChannel = c.commandChannel
-	}
-
-	if c.emulated {
+	} else if c.device != "" {
+		// Open the specified TPM device and create a command channel from it
+		tpmTransport, err := transport.OpenTPM(c.device)
+		if err != nil {
+			return nil, fmt.Errorf("opening TPM device %s: %w", c.device, err)
+		}
+		cfg.CommandChannel = backend.FromTransport(tpmTransport)
+	} else if c.emulated {
 		var sim *simulator.Simulator
 		var err error
 		if c.seed != 0 {


### PR DESCRIPTION
because otherwise the consumers (e.g. https://github.com/kairos-io/kcrypt-discovery-challenger/pull/146) can't define the device to be used. 

The device specified in the config was completely ignored in kcrypt-challenger (e.g. no error was produced when I passed `--tpm-device /dev/null`). With this change, it works.